### PR TITLE
Update 김태정화학0313.ipynb

### DIFF
--- a/김태정화학0313.ipynb
+++ b/김태정화학0313.ipynb
@@ -436,7 +436,7 @@
         "print(color1)\n",
         "print(color2)\n",
         "clear color1\n",
-        "print(color1)"
+        "#print(color1)"
       ],
       "metadata": {
         "colab": {


### PR DESCRIPTION
변수를 clear한 코드 뒤로 print시켰기 때문에  NameError 발생. 해당부분 주석처리하여 없앴음.